### PR TITLE
Login error message display

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -2,7 +2,7 @@ from app import app
 from flask import render_template, request, redirect, url_for, flash, session
 from werkzeug.security import generate_password_hash, check_password_hash
 from app.model import User, db
-from app.form import SignupForm, LoginForm, UploadForm
+from app.forms import SignupForm, LoginForm, UploadForm
 from functools import wraps
 from io import BytesIO
 


### PR DESCRIPTION
1. Fixed an error on the login page where entering an incorrect password did not result in any prompts, now the red error message is displayed correctly.
2. Changed the flash logic in `minimal_base.html` to prevent error messages from being shown as green toast.